### PR TITLE
Stop build spam

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ m4_define(pkg_int_version, (pkg_major_version * 100 + pkg_minor_version) * 100 +
 
 AC_PREREQ(2.61)
 AC_INIT([cjs], pkg_version, [https://github.com/linuxmint/cjs])
-AM_INIT_AUTOMAKE([dist-xz no-dist-gzip])
+AM_INIT_AUTOMAKE([dist-xz no-dist-gzip subdir-objects])
 AC_CONFIG_SRCDIR([cjs/console.cpp])
 AC_CONFIG_HEADER([config.h])
 


### PR DESCRIPTION
```
Makefile-modules.am:32: warning: source file 'modules/cairo-context.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
Makefile-modules.am:32: warning: source file 'modules/cairo-path.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo-surface.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo-image-surface.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo-ps-surface.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo-pdf-surface.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo-svg-surface.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo-pattern.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo-gradient.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo-linear-gradient.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo-radial-gradient.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo-surface-pattern.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo-solid-pattern.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-modules.am:32: warning: source file 'modules/cairo.cpp' is in a subdirectory,
Makefile-modules.am:32: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile.am:106: warning: source file 'cjs/byteArray.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/context.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/importer.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/gi.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/coverage.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/jsapi-private.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/jsapi-util.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/jsapi-dynamic-class.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/jsapi-util-array.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/jsapi-util-error.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/jsapi-util-string.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/mem.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/native.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/runtime.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/stack.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'cjs/type-module.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'modules/modules.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'util/error.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'util/hash-x32.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'util/glib.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'util/crash.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'util/log.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'util/misc.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/arg.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/boxed.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/closure.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/enumeration.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/function.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/keep-alive.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/ns.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/object.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/foreign.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/fundamental.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/param.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/proxyutils.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/repo.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/union.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/value.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/interface.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/gtype.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:106: warning: source file 'gi/gerror.cpp' is in a subdirectory,
Makefile.am:106: but option 'subdir-objects' is disabled
Makefile.am:156: warning: source file 'libgjs-private/gjs-gdbus-wrapper.cpp' is in a subdirectory,
Makefile.am:156: but option 'subdir-objects' is disabled
Makefile.am:156: warning: source file 'libgjs-private/gjs-util.cpp' is in a subdirectory,
Makefile.am:156: but option 'subdir-objects' is disabled
Makefile.am:164: warning: source file 'libgjs-private/gjs-gtk-util.c' is in a subdirectory,
Makefile.am:164: but option 'subdir-objects' is disabled
Makefile-modules.am:56: warning: source file 'modules/console.cpp' is in a subdirectory,
Makefile-modules.am:56: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-insttest.am:63: warning: source file '$(GI_DATADIR)/tests/gimarshallingtests.c' is in a subdirectory,
Makefile-insttest.am:63: but option 'subdir-objects' is disabled
Makefile.am:227:   'Makefile-insttest.am' included from here
Makefile-insttest.am:46: warning: source file '$(GI_DATADIR)/tests/regress.c' is in a subdirectory,
Makefile-insttest.am:46: but option 'subdir-objects' is disabled
Makefile.am:227:   'Makefile-insttest.am' included from here
Makefile-modules.am:52: warning: source file 'modules/system.cpp' is in a subdirectory,
Makefile-modules.am:52: but option 'subdir-objects' is disabled
Makefile.am:202:   'Makefile-modules.am' included from here
Makefile-insttest.am:59: warning: source file '$(GI_DATADIR)/tests/warnlib.c' is in a subdirectory,
Makefile-insttest.am:59: but option 'subdir-objects' is disabled
Makefile.am:227:   'Makefile-insttest.am' included from here
Makefile.am:221: warning: source file 'cjs/console.cpp' is in a subdirectory,
Makefile.am:221: but option 'subdir-objects' is disabled
Makefile-test.am:38: warning: source file 'test/gjs-tests.cpp' is in a subdirectory,
Makefile-test.am:38: but option 'subdir-objects' is disabled
Makefile.am:226:   'Makefile-test.am' included from here
Makefile-test.am:38: warning: source file 'test/gjs-test-coverage.cpp' is in a subdirectory,
Makefile-test.am:38: but option 'subdir-objects' is disabled
Makefile.am:226:   'Makefile-test.am' included from here
Makefile-insttest.am:29: warning: source file 'installed-tests/gjs-unit.cpp' is in a subdirectory,
Makefile-insttest.am:29: but option 'subdir-objects' is disabled
Makefile.am:227:   'Makefile-insttest.am' included from here
```