### PR TITLE
Lower gobject-introspection requirement to 1.38.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,7 @@ m4_define(glib_required_version, 2.36.0)
 AC_CHECK_HEADERS([malloc.h])
 AC_CHECK_FUNCS(mallinfo)
 
-GOBJECT_INTROSPECTION_REQUIRE([1.39.3])
+GOBJECT_INTROSPECTION_REQUIRE([1.38.0])
 
 common_packages="gmodule-2.0 gthread-2.0 gio-2.0 >= glib_required_version mozjs-24"
 gjs_packages="gobject-introspection-1.0 libffi $common_packages"


### PR DESCRIPTION
cjs compiles fine with 1.38.0
