### PR TITLE
Migrate away from gnome-common deprecated vars and macros

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,6 +92,7 @@ libcjs_la_CFLAGS = 		\
 	$(AM_CFLAGS)
 libcjs_la_LDFLAGS = 		\
 	$(EXTRA_LINK_FLAGS)	\
+	$(WARN_LDFLAGS)         \
 	-export-symbols-regex "^[^_]" -version-info 0:0:0	\
 	-no-undefined \
 	-rdynamic
@@ -217,7 +218,7 @@ cjs_console_LDADD =		\
 	$(JS_LIBS)		\
 	$(GOBJECT_LIBS)		\
 	libcjs.la
-cjs_console_LDFLAGS = -rdynamic
+cjs_console_LDFLAGS = $(WARN_LDFLAGS) -rdynamic
 cjs_console_SOURCES = cjs/console.cpp
 
 install-exec-hook:

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,44 +1,40 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="gjs"
-REQUIRED_AUTOCONF_VERSION=2.53
-REQUIRED_AUTOMAKE_VERSION=1.7.2
+cd $srcdir
 
-(test -f $srcdir/configure.ac \
-  && test -f $srcdir/autogen.sh) || {
-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level $PKG_NAME directory"
+(test -f configure.ac) || {
+    echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
     exit 1
 }
 
-DIE=0
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
 
-# This is a bit complicated here since we can't use gnome-config yet.
-# It'll be easier after switching to pkg-config since we can then
-# use pkg-config to find the gnome-autogen.sh script.
-
-gnome_autogen=
-gnome_datadir=
-
-ifs_save="$IFS"; IFS=":"
-for dir in $PATH ; do
-  test -z "$dir" && dir=.
-  if test -f $dir/gnome-autogen.sh ; then
-    gnome_autogen="$dir/gnome-autogen.sh"
-    gnome_datadir=`echo $dir | sed -e 's,/bin$,/share,'`
-    break
-  fi
-done
-IFS="$ifs_save"
-
-if test -z "$gnome_autogen" ; then
-  echo "You need to install the gnome-common module and make"
-  echo "sure the gnome-autogen.sh script is in your \$PATH."
-  exit 1
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+    echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+    echo "*** If you wish to pass any to it, please specify them on the" >&2
+    echo "*** '$0' command line." >&2
+    echo "" >&2
 fi
 
-GNOME_DATADIR="$gnome_datadir" USE_GNOME2_MACROS=1 . $gnome_autogen
+aclocal --install || exit 1
+glib-gettextize --force --copy || exit 1
+gtkdocize --copy || exit 1
+intltoolize --force --copy --automake || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+    $srcdir/configure "$@" || exit 1
+
+    if [ "$1" = "--help" ]; then exit 0 else
+        echo "Now type 'make' to compile $PKG_NAME" || exit 1
+    fi
+else
+    echo "Skipping configure process."
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,8 @@ m4_define(pkg_int_version, (pkg_major_version * 100 + pkg_minor_version) * 100 +
 
 AC_PREREQ(2.61)
 AC_INIT([cjs], pkg_version, [https://github.com/linuxmint/cjs])
+AC_CONFIG_MACRO_DIR([m4])
+AX_IS_RELEASE([git-directory])
 AM_INIT_AUTOMAKE([dist-xz no-dist-gzip])
 AC_CONFIG_SRCDIR([cjs/console.cpp])
 AC_CONFIG_HEADER([config.h])
@@ -40,8 +42,7 @@ dnl DOLT
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 
-GNOME_CXX_WARNINGS([maximum])
-GNOME_MAINTAINER_MODE_DEFINES
+AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS])
 
 # coverage
 AC_ARG_ENABLE([coverage],


### PR DESCRIPTION
gnome-common is deprecating some vars and macros, listed here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829932

This change follows the gnome recommendations from:
https://wiki.gnome.org/Projects/GnomeCommon/Migration

Please note that this still depends on gnome-common.