### PR TITLE
Migrate away from gnome-common deprecated vars and macros

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -23,9 +23,6 @@ if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
 fi
 
 aclocal --install || exit 1
-glib-gettextize --force --copy || exit 1
-gtkdocize --copy || exit 1
-intltoolize --force --copy --automake || exit 1
 autoreconf --verbose --force --install || exit 1
 
 cd "$olddir"

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,9 @@ m4_define(pkg_int_version, (pkg_major_version * 100 + pkg_minor_version) * 100 +
 AC_PREREQ(2.61)
 AC_INIT([cjs], pkg_version, [https://github.com/linuxmint/cjs])
 AC_CONFIG_MACRO_DIR([m4])
-AX_IS_RELEASE([always])
+
+m4_ifdef([AX_IS_RELEASE], [AX_IS_RELEASE([always])])
+
 AM_INIT_AUTOMAKE([dist-xz no-dist-gzip])
 AC_CONFIG_SRCDIR([cjs/console.cpp])
 AC_CONFIG_HEADER([config.h])
@@ -42,7 +44,8 @@ dnl DOLT
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 
-AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS])
+m4_ifdef([AX_COMPILER_FLAGS],
+         [AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS])])
 
 # coverage
 AC_ARG_ENABLE([coverage],


### PR DESCRIPTION
gnome-common is deprecating some vars and macros, listed here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829932

This change follows the gnome recommendations from:
https://wiki.gnome.org/Projects/GnomeCommon/Migration