### PR TITLE
tweener: Add undefined property check

### DIFF
--- a/modules/tweener/tweener.js
+++ b/modules/tweener/tweener.js
@@ -542,7 +542,7 @@ function _addTweenOrCaller(target, tweeningParameters, isCaller) {
                 copyProperties[istr] = new PropertyInfo(properties[istr].valueStart,
                                                         properties[istr].valueComplete,
                                                         properties[istr].valueComplete,
-                                                        properties[istr].arrayIndex,
+                                                        properties[istr].arrayIndex || 0,
                                                         {},
                                                         properties[istr].isSpecialProperty,
                                                         properties[istr].modifierFunction,


### PR DESCRIPTION
Based on https://git.gnome.org/browse/gjs/commit/?id=e606a06ecbfaf29d23b37d81851c125f077f20a8

Fixes nermo-preview warning

```
Cjs-Message: JS WARNING: [resource:///org/cinnamon/cjs/modules/tweener/tweener.js 545]: reference to undefined property properties[istr].arrayIndex
```