### PR TITLE
arg: don't crash when asked to convert a null strv to an array

### DIFF
--- a/gi/arg.cpp
+++ b/gi/arg.cpp
@@ -572,7 +572,13 @@ gjs_array_from_strv(JSContext             *context,
     guint i;
     JS::AutoValueVector elems(context);
 
-    for (i = 0; strv[i] != NULL; i++) {
+    /* We treat a NULL strv as an empty array, since this function should always
+     * set an array value when returning true.
+     * Another alternative would be to set value_p to JS::NullValue, but clients
+     * would need to always check for both an empty array and null if that was
+     * the case.
+     */
+    for (i = 0; strv != NULL && strv[i] != NULL; i++) {
         elems.growBy(1);
         if (!gjs_string_from_utf8(context, strv[i], -1, elems[i]))
             return false;


### PR DESCRIPTION
Based on https://git.gnome.org/browse/gjs/commit/?h=gnome-3-24&id=cd027725d23d39afdba67a7b64be29e7b5db4171

https://bugzilla.gnome.org/show_bug.cgi?id=775679