### PR TITLE
[3.8] Promises: Change idle_add priority to PRIORITY_DEFAULT in the timer wrapper

### DIFF
--- a/modules/_lie.js
+++ b/modules/_lie.js
@@ -5,7 +5,7 @@ const GLib = imports.gi.GLib;
 
 var reqs = {
   immediate: function () {
-    return function (func, priority=GLib.PRIORITY_DEFAULT_IDLE) {
+    return function (func, priority=GLib.PRIORITY_DEFAULT) {
       GLib.idle_add(priority, function () {
         func();
         return GLib.SOURCE_REMOVE;


### PR DESCRIPTION
The timer for promises should be changed to a 0ms delay (which just waits for the call stack to clear like setImmediate) so promises work accurately with this implementation. The next major version of GJS scraps this polyfill entirely for the [Mozilla implementation](https://github.com/GNOME/gjs/commit/4570bb5bc1e71f371c324ac618f4087262095cfb), so it is a temporary fix.

The library this is supposed to emulate is an [npm package called immediate](https://github.com/calvinmetcalf/immediate), and it doesn't use a hard coded 200ms delay.