### PR TITLE
value: Fix memory leak while marshalling GValue

### DIFF
--- a/gi/value.cpp
+++ b/gi/value.cpp
@@ -532,6 +532,7 @@ gjs_value_to_g_value_internal(JSContext      *context,
                 return false;
 
             g_value_set_boxed(gvalue, &nested_gvalue);
+            g_value_unset(&nested_gvalue);
             return true;
         }
 


### PR DESCRIPTION
https://github.com/GNOME/gjs/commit/61b1d8d2f601486954fa4141e3bde47b68ea106d