### PR TITLE
Fix scope warning for restrictedWords in the tweener module

### DIFF
--- a/modules/tweener/tweener.js
+++ b/modules/tweener/tweener.js
@@ -368,7 +368,7 @@ function _onEnterFrame() {
     return true;
 };
 
-const restrictedWords = {
+var restrictedWords = {
     time: true,
     delay: true,
     userFrames: true,


### PR DESCRIPTION
> Cjs-WARNING **: Some code accessed the property 'restrictedWords' on the module 'tweener'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.