### PR TITLE
Make importer properties configurable, fix xlet reloading

### DIFF
--- a/cjs/importer.cpp
+++ b/cjs/importer.cpp
@@ -216,7 +216,7 @@ seal_import(JSContext       *cx,
         return false;
     }
 
-    descr.setConfigurable(false);
+    descr.setConfigurable(true);
     if (!JS_DefinePropertyById(cx, descr.object(), id, descr)) {
         gjs_debug(GJS_DEBUG_IMPORTER,
                   "Failed to redefine attributes to seal '%s' in importer",


### PR DESCRIPTION
This makes properties on the importer object removable. This allows us to use `delete` on importer properties, and allows Spidermonkey to GC the object, which propagates to GJS with a correct finalization of the GjsModule.