### PR TITLE
Fix two broken test cases

### DIFF
--- a/installed-tests/js/testSystem.js
+++ b/installed-tests/js/testSystem.js
@@ -12,7 +12,7 @@ describe('System.addressOf()', function () {
 describe('System.version', function () {
     it('gives a plausible number', function () {
         expect(System.version).not.toBeLessThan(14700);
-        expect(System.version).toBeLessThan(40000);
+        expect(System.version).toBeLessThan(50000);
     });
 });
 

--- a/installed-tests/scripts/testCommandLine.sh
+++ b/installed-tests/scripts/testCommandLine.sh
@@ -149,7 +149,7 @@ report "--coverage-prefix after script should succeed but give a warning"
 $gjs -c 'imports.system.exit(0)' --coverage-prefix=foo --coverage-output=foo 2>&1 | grep -q 'Cjs-WARNING.*--coverage-output'
 report "--coverage-output after script should succeed but give a warning"
 rm -f foo/coverage.lcov
-$gjs -c 'imports.system.exit(0)' --profile=foo 2>&1 | grep -q 'Gjs-WARNING.*--profile'
+$gjs -c 'imports.system.exit(0)' --profile=foo 2>&1 | grep -q 'Cjs-WARNING.*--profile'
 report "--profile after script should succeed but give a warning"
 rm -f foo
 


### PR DESCRIPTION
1. System.version check was set as 4.0.0 max, but we just crossed the version threshold, so set it to 5.0.0 max.
2. Fix old broken reference from `Gjs-WARNING` to `Cjs-WARNING`