### PR TITLE
fix failing test checking for version number

### DIFF
--- a/installed-tests/js/testSystem.js
+++ b/installed-tests/js/testSystem.js
@@ -11,8 +11,8 @@ describe('System.addressOf()', function () {
 
 describe('System.version', function () {
     it('gives a plausible number', function () {
-        expect(System.version).not.toBeLessThan(14700);
-        expect(System.version).toBeLessThan(50000);
+        expect(System.version).not.toBeLessThan(40802);
+        expect(System.version).toBeLessThan(60000);
     });
 });
 


### PR DESCRIPTION
Now we reached 5.x, the version number cjs reports is no longer compatible with this test, which needs to be periodically bumped on every major release.

There should be a better way to handle this... but for now I narrowed down both the lower and upper bounds to fit into ~current.