### PR TITLE
build: unbreak with meson >= 0.60.2 

### DIFF
--- a/installed-tests/js/meson.build
+++ b/installed-tests/js/meson.build
@@ -48,7 +48,7 @@ regress_gir = gnome.generate_gir(libregress, includes: regress_gir_includes,
     sources: regress_sources, namespace: 'Regress', nsversion: '1.0',
     identifier_prefix: 'Regress', symbol_prefix: 'regress_',
     extra_args: ['--warn-all', '--warn-error'] + regress_gir_c_args,
-    install: get_option('installed_tests'), install_dir_gir: false,
+    install: get_option('installed_tests'), install_dir_gir: [false],
     install_dir_typelib: installed_tests_execdir)
 regress_typelib = regress_gir[1]
 
@@ -66,7 +66,7 @@ libwarnlib = library('warnlib', warnlib_sources,
 warnlib_gir = gnome.generate_gir(libwarnlib, includes: ['Gio-2.0'],
     sources: warnlib_sources, namespace: 'WarnLib', nsversion: '1.0',
     symbol_prefix: 'warnlib_', header: 'warnlib.h',
-    install: get_option('installed_tests'), install_dir_gir: false,
+    install: get_option('installed_tests'), install_dir_gir: [false],
     install_dir_typelib: installed_tests_execdir)
 warnlib_typelib = warnlib_gir[1]
 
@@ -82,7 +82,7 @@ gimarshallingtests_gir = gnome.generate_gir(libgimarshallingtests,
     includes: ['Gio-2.0'], sources: gimarshallingtests_sources,
     namespace: 'GIMarshallingTests', nsversion: '1.0',
     symbol_prefix: 'gi_marshalling_tests_', extra_args: '--warn-error',
-    install: get_option('installed_tests'), install_dir_gir: false,
+    install: get_option('installed_tests'), install_dir_gir: [false],
     install_dir_typelib: installed_tests_execdir)
 gimarshallingtests_typelib = gimarshallingtests_gir[1]
 

--- a/meson.build
+++ b/meson.build
@@ -542,7 +542,7 @@ gjs_private_gir = gnome.generate_gir(libgjs,
     includes: ['GObject-2.0', 'Gio-2.0'], sources: libgjs_private_sources,
     namespace: 'CjsPrivate', nsversion: '1.0', identifier_prefix: 'Gjs',
     symbol_prefix: 'gjs_', extra_args: '--warn-error', install: true,
-    install_dir_gir: false, install_dir_typelib: pkglibdir / 'girepository-1.0')
+    install_dir_gir: [false], install_dir_typelib: pkglibdir / 'girepository-1.0')
 gjs_private_typelib = gjs_private_gir[1]
 
 ### Build gjs-console interpreter ##############################################


### PR DESCRIPTION
Regressed by [meson@5cc166a66](https://github.com/mesonbuild/meson/commit/5cc166a667ff). Fix based on [gjs#694](https://gitlab.gnome.org/GNOME/gjs/-/merge_requests/694). From [error log](http://www.ipv6proxy.net/go.php?u=http://package22.nyi.freebsd.org/data/130amd64-default-foo/2021-11-26_20h00m58s/logs/cjs-4.8.2.log):
```python
$ meson setup _build
[...]
meson.build:541:0: ERROR: "install_dir" must be specified when installing a target
```
Dropping `install: true` doesn't help:
```
Error: Missing: lib/cjs/girepository-1.0/CjsPrivate-1.0.typelib
```
Dropping `install_dir_gir: false` doesn't help:
```
Error: Orphaned: share/gir-1.0/CjsPrivate-1.0.gir
```
Adding `install_dir` doesn't help:
```
meson.build:541:0: ERROR: Got unknown keyword arguments "install_dir"
```
