### PR TITLE
Revert "build: disable gir install via list to pacify meson >= 0.60.2 (#98)"

### DIFF
--- a/installed-tests/js/meson.build
+++ b/installed-tests/js/meson.build
@@ -48,7 +48,7 @@ regress_gir = gnome.generate_gir(libregress, includes: regress_gir_includes,
     sources: regress_sources, namespace: 'Regress', nsversion: '1.0',
     identifier_prefix: 'Regress', symbol_prefix: 'regress_',
     extra_args: ['--warn-all', '--warn-error'] + regress_gir_c_args,
-    install: get_option('installed_tests'), install_dir_gir: [false],
+    install: get_option('installed_tests'), install_dir_gir: false,
     install_dir_typelib: installed_tests_execdir)
 regress_typelib = regress_gir[1]
 
@@ -66,7 +66,7 @@ libwarnlib = library('warnlib', warnlib_sources,
 warnlib_gir = gnome.generate_gir(libwarnlib, includes: ['Gio-2.0'],
     sources: warnlib_sources, namespace: 'WarnLib', nsversion: '1.0',
     symbol_prefix: 'warnlib_', header: 'warnlib.h',
-    install: get_option('installed_tests'), install_dir_gir: [false],
+    install: get_option('installed_tests'), install_dir_gir: false,
     install_dir_typelib: installed_tests_execdir)
 warnlib_typelib = warnlib_gir[1]
 
@@ -82,7 +82,7 @@ gimarshallingtests_gir = gnome.generate_gir(libgimarshallingtests,
     includes: ['Gio-2.0'], sources: gimarshallingtests_sources,
     namespace: 'GIMarshallingTests', nsversion: '1.0',
     symbol_prefix: 'gi_marshalling_tests_', extra_args: '--warn-error',
-    install: get_option('installed_tests'), install_dir_gir: [false],
+    install: get_option('installed_tests'), install_dir_gir: false,
     install_dir_typelib: installed_tests_execdir)
 gimarshallingtests_typelib = gimarshallingtests_gir[1]
 

--- a/meson.build
+++ b/meson.build
@@ -542,7 +542,7 @@ gjs_private_gir = gnome.generate_gir(libgjs,
     includes: ['GObject-2.0', 'Gio-2.0'], sources: libgjs_private_sources,
     namespace: 'CjsPrivate', nsversion: '1.0', identifier_prefix: 'Gjs',
     symbol_prefix: 'gjs_', extra_args: '--warn-error', install: true,
-    install_dir_gir: [false], install_dir_typelib: pkglibdir / 'girepository-1.0')
+    install_dir_gir: false, install_dir_typelib: pkglibdir / 'girepository-1.0')
 gjs_private_typelib = gjs_private_gir[1]
 
 ### Build gjs-console interpreter ##############################################


### PR DESCRIPTION
This reverts commit a4f6cfc521094afc4acb349a77fee2f7b1ebf6e3.

This commit was wrong, because it tried to work around a bug in a single version of meson by using something that isn't, wasn't, and won't be a valid value.

The fixed version of meson 0.60.x has been out for a while now, which once again accepts `false`, and 0.61.0 also accepts `false` but was known at the time of this workaround to not work in meson-git master (now meson 0.61.0).

Using `false` is acceptable and the failure to accept it has been qualified as a meson regression. Using `[false]` is just... trying to fuzz meson with random objects until you get something that slips its way through the argument checker and produces desired effects on the python implementation level.