### PR TITLE
Fix meson.build deprecations up to 0.56.0 (#119)

### DIFF
--- a/installed-tests/js/libgjstesttools/meson.build
+++ b/installed-tests/js/libgjstesttools/meson.build
@@ -13,7 +13,7 @@ libgjstesttools = library('gjstesttools',
 gjstest_tools_gir = gnome.generate_gir(libgjstesttools,
     includes: ['GObject-2.0', 'Gio-2.0'], sources: gjstest_tools_sources,
     namespace: 'GjsTestTools', nsversion: '1.0',
-    symbol_prefix: 'gjs_test_tools_', extra_args: '--warn-error',
+    symbol_prefix: 'gjs_test_tools_', fatal_warnings: get_option('werror'),
     install: get_option('installed_tests'), install_dir_gir: false,
     install_dir_typelib: installed_tests_execdir)
 gjstest_tools_typelib = gjstest_tools_gir[1]

--- a/installed-tests/js/meson.build
+++ b/installed-tests/js/meson.build
@@ -73,9 +73,10 @@ libregress = library('regress', regress_sources,
 regress_gir = gnome.generate_gir(libregress, includes: regress_gir_includes,
     sources: regress_sources, namespace: 'Regress', nsversion: '1.0',
     identifier_prefix: 'Regress', symbol_prefix: 'regress_',
-    extra_args: ['--warn-all', '--warn-error'] + regress_gir_c_args,
+    extra_args: ['--warn-all'] + regress_gir_c_args,
     install: get_option('installed_tests'), install_dir_gir: false,
-    install_dir_typelib: installed_tests_execdir)
+    install_dir_typelib: installed_tests_execdir,
+    fatal_warnings: get_option('werror'))
 regress_typelib = regress_gir[1]
 
 if not skip_warnlib
@@ -104,7 +105,7 @@ libgimarshallingtests = library('gimarshallingtests',
 gimarshallingtests_gir = gnome.generate_gir(libgimarshallingtests,
     includes: ['Gio-2.0'], sources: gimarshallingtests_sources,
     namespace: 'GIMarshallingTests', nsversion: '1.0',
-    symbol_prefix: 'gi_marshalling_tests_', extra_args: '--warn-error',
+    symbol_prefix: 'gi_marshalling_tests_', fatal_warnings: get_option('werror'),
     install: get_option('installed_tests'), install_dir_gir: false,
     install_dir_typelib: installed_tests_execdir)
 gimarshallingtests_typelib = gimarshallingtests_gir[1]

--- a/meson.build
+++ b/meson.build
@@ -595,7 +595,7 @@ libgjs_dep = declare_dependency(link_with: [libgjs, libgjs_jsapi],
 gjs_private_gir = gnome.generate_gir(libgjs,
     includes: ['GObject-2.0', 'Gio-2.0'], sources: libgjs_private_sources,
     namespace: 'CjsPrivate', nsversion: '1.0', identifier_prefix: 'Gjs',
-    symbol_prefix: 'gjs_', extra_args: '--warn-error', install: true,
+    symbol_prefix: 'gjs_', fatal_warnings: get_option('werror'), install: true,
     install_dir_gir: false, install_dir_typelib: pkglibdir / 'girepository-1.0')
 gjs_private_typelib = gjs_private_gir[1]
 
@@ -642,7 +642,7 @@ js_tests_builddir = meson.current_build_dir() / 'installed-tests' / 'js'
 libgjs_test_tools_builddir = js_tests_builddir / 'libgjstesttools'
 # GJS_PATH is empty here since we want to force the use of our own
 # resources. G_FILENAME_ENCODING ensures filenames are not UTF-8
-tests_environment.set('TOP_BUILDDIR', meson.build_root())
+tests_environment.set('TOP_BUILDDIR', meson.project_build_root())
 tests_environment.set('GJS_USE_UNINSTALLED_FILES', '1')
 tests_environment.set('GJS_PATH', '')
 tests_environment.set('GJS_DEBUG_OUTPUT', 'stderr')


### PR DESCRIPTION
Add commit lost during the last rebase.

Fixes #123 