### PR TITLE
importer: Add 'clear_cache' function to allow reloading of modules.

### DIFF
--- a/cjs/atoms.h
+++ b/cjs/atoms.h
@@ -19,6 +19,7 @@ class JSTracer;
 // clang-format off
 #define FOR_EACH_ATOM(macro) \
     macro(cause, "cause") \
+    macro(clear_cache, "clearCache") \
     macro(code, "code") \
     macro(column_number, "columnNumber") \
     macro(connect_after, "connect_after") \


### PR DESCRIPTION
We used to do something similar in very old versions of cjs before linuxmint/cinnamon@f01bd803d5ae89.